### PR TITLE
Refactor database access and add RabbitMQ message producer

### DIFF
--- a/src/Keel.Infra.Db/Access/DbDapperAccess.cs
+++ b/src/Keel.Infra.Db/Access/DbDapperAccess.cs
@@ -1,5 +1,4 @@
 ﻿using System.Data;
-using System.Data.Common;
 using Dapper;
 using Keel.Infra.Db.Access.Context;
 
@@ -7,7 +6,7 @@ namespace Keel.Infra.Db.Access;
 
 public class DbDapperAccess(IDbSharedContextProvider sharedConnectionProvider)
 {
-    public async Task<T?> ReadOneAsync<T>(string sql, object? param = null, CancellationToken cancellationToken = default)
+    public async Task<T?> ReadOneAsync<T>(string sql, object? param, CancellationToken cancellationToken)
     {
         using var context = await sharedConnectionProvider.GetContextAsync(cancellationToken);
         var connection = context.Connection;
@@ -19,7 +18,7 @@ public class DbDapperAccess(IDbSharedContextProvider sharedConnectionProvider)
                 commandType: CommandType.Text,
                 transaction: context.Transaction);
     }
-    public async Task<T?> ReadOneSpAsync<T>(string sql, object? param = null, CancellationToken cancellationToken = default)
+    public async Task<T?> ReadOneSpAsync<T>(string sql, object? param, CancellationToken cancellationToken)
     {
         using var context = await sharedConnectionProvider.GetContextAsync(cancellationToken);
         var connection = context.Connection;
@@ -31,7 +30,7 @@ public class DbDapperAccess(IDbSharedContextProvider sharedConnectionProvider)
             transaction: context.Transaction);
     }
 
-    public async Task<IEnumerable<T>> ReadAsync<T>(string sql, object? param = null, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<T>> ReadAsync<T>(string sql, object? param, CancellationToken cancellationToken)
     {
         using var context = await sharedConnectionProvider.GetContextAsync(cancellationToken);
         var connection = context.Connection;
@@ -42,8 +41,7 @@ public class DbDapperAccess(IDbSharedContextProvider sharedConnectionProvider)
             commandType: CommandType.Text, 
             transaction: context.Transaction);
     }
-
-    public async Task<IEnumerable<T>> ReadSpAsync<T>(string sql, object? param = null, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<T>> ReadSpAsync<T>(string sql, object? param, CancellationToken cancellationToken)
     {
         using var context = await sharedConnectionProvider.GetContextAsync(cancellationToken);
         var connection = context.Connection;
@@ -54,7 +52,7 @@ public class DbDapperAccess(IDbSharedContextProvider sharedConnectionProvider)
             commandType: CommandType.StoredProcedure, 
             transaction: context.Transaction);
     }
-    public async Task<IEnumerable<T>> ReadSpAsync<T>(string sql, int commandTimeout, object? param = null, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<T>> ReadSpAsync<T>(string sql, int commandTimeout, object? param, CancellationToken cancellationToken)
     {
         using var context = await sharedConnectionProvider.GetContextAsync(cancellationToken);
         var connection = context.Connection;
@@ -67,7 +65,7 @@ public class DbDapperAccess(IDbSharedContextProvider sharedConnectionProvider)
             commandTimeout: commandTimeout);
     }
 
-    public async Task<IEnumerable<TResult>> QueryAsync<TResult>(Action<DbDapperAccessBuilder> config, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<TResult>> QueryAsync<TResult>(Action<DbDapperAccessBuilder> config, CancellationToken cancellationToken)
     {
         using var context = await sharedConnectionProvider.GetContextAsync(cancellationToken);
         var connection = context.Connection;
@@ -82,77 +80,5 @@ public class DbDapperAccess(IDbSharedContextProvider sharedConnectionProvider)
         }
 
         return await connection.QueryAsync<TResult>(builder.Build(context.Transaction, cancellationToken));
-    }
-}
-
-public class DbDapperAccessBuilder
-{
-    private readonly DynamicParameters _parameters = new();
-
-    private int? _commandTimeout;
-    private string _commandText = null!;
-    private CommandType _commandType;
-
-    public DbDapperAccessBuilder ForCommand(string command, CommandType commandType)
-    {
-        _commandText = command;
-        _commandType = commandType;
-
-        return this;
-    }
-
-    public DbDapperAccessBuilder ForText(string command)
-    {
-        _commandText = command;
-        _commandType = CommandType.Text;
-
-        return this;
-    }
-
-    public DbDapperAccessBuilder ForStoredProc(string command)
-    {
-        _commandText = command;
-        _commandType = CommandType.StoredProcedure;
-
-        return this;
-    }
-
-    public DbDapperAccessBuilder WithTimeout(int timeout)
-    {
-        _commandTimeout = timeout;
-
-        return this;
-    }
-
-    public DbDapperAccessBuilder AddInt(string name, int value)
-    {
-        _parameters.Add(name, value, DbType.Int32);
-
-        return this;
-    }
-
-    public DbDapperAccessBuilder AddDateTime(string name, DateTime value)
-    {
-        _parameters.Add(name, value, DbType.DateTime);
-
-        return this;
-    }
-
-    public DbDapperAccessBuilder AddString(string name, string value)
-    {
-        _parameters.Add(name, value, DbType.String);
-
-        return this;
-    }
-
-    public CommandDefinition Build(DbTransaction? transaction, CancellationToken cancellationToken)
-    {
-        return new CommandDefinition(
-            _commandText,
-            _parameters,
-            transaction,
-            _commandTimeout,
-            _commandType,
-            cancellationToken: cancellationToken);
     }
 }

--- a/src/Keel.Infra.Db/Access/DbDapperAccessBuilder.cs
+++ b/src/Keel.Infra.Db/Access/DbDapperAccessBuilder.cs
@@ -1,0 +1,77 @@
+using System.Data;
+using System.Data.Common;
+using Dapper;
+
+namespace Keel.Infra.Db.Access;
+
+public class DbDapperAccessBuilder
+{
+    private readonly DynamicParameters _parameters = new();
+
+    private int? _commandTimeout;
+    private string _commandText = null!;
+    private CommandType _commandType;
+
+    public DbDapperAccessBuilder ForCommand(string command, CommandType commandType)
+    {
+        _commandText = command;
+        _commandType = commandType;
+
+        return this;
+    }
+
+    public DbDapperAccessBuilder ForText(string command)
+    {
+        _commandText = command;
+        _commandType = CommandType.Text;
+
+        return this;
+    }
+
+    public DbDapperAccessBuilder ForStoredProc(string command)
+    {
+        _commandText = command;
+        _commandType = CommandType.StoredProcedure;
+
+        return this;
+    }
+
+    public DbDapperAccessBuilder WithTimeout(int timeout)
+    {
+        _commandTimeout = timeout;
+
+        return this;
+    }
+
+    public DbDapperAccessBuilder AddInt(string name, int? value)
+    {
+        _parameters.Add(name, value, DbType.Int32);
+
+        return this;
+    }
+
+    public DbDapperAccessBuilder AddDateTime(string name, DateTime value)
+    {
+        _parameters.Add(name, value, DbType.DateTime);
+
+        return this;
+    }
+
+    public DbDapperAccessBuilder AddString(string name, string value)
+    {
+        _parameters.Add(name, value, DbType.String);
+
+        return this;
+    }
+
+    public CommandDefinition Build(DbTransaction? transaction, CancellationToken cancellationToken)
+    {
+        return new CommandDefinition(
+            _commandText,
+            _parameters,
+            transaction,
+            _commandTimeout,
+            _commandType,
+            cancellationToken: cancellationToken);
+    }
+}

--- a/src/Keel.Infra.Db/Access/DbDirectAccess.cs
+++ b/src/Keel.Infra.Db/Access/DbDirectAccess.cs
@@ -1,9 +1,8 @@
 ﻿using System.Data;
 using System.Data.Common;
 using DotNetAppBase.Std.Db.Work;
+using DotNetAppBase.Std.Exceptions.Bussines;
 using Keel.Infra.Db.Access.Context;
-
-// ReSharper disable UnusedMember.Global
 
 namespace Keel.Infra.Db.Access;
 
@@ -169,6 +168,98 @@ public abstract class DbDirectAccess(IDbSharedContextProvider provider)
         }
     }
     
+    public async Task<TResult> QueryAsync<TResult>(Action<DbDirectAccessBuilder> config, CancellationToken cancellationToken)
+    {
+        var context = await provider.GetContextAsync(cancellationToken).ConfigureAwait(false);
+        await using var comm = context.CreateCommand();
+
+        var builder = new DbDirectAccessBuilder(this, comm);
+        
+        config(builder);
+
+        builder.SetExecutionByReturnType<TResult>();
+        if (builder.Mode == DbDirectAccessBuilder.EExecMode.PrimitiveValue)
+        {
+            return (TResult)(object)comm.ExecuteScalarAsync(cancellationToken);
+        }
+
+        var set = new DataSet();
+
+        using var adapter = InternalCreateDataAdapter(comm);
+
+        await Task.Run(() => adapter.Fill(set), cancellationToken);
+
+        if (builder.Mode == DbDirectAccessBuilder.EExecMode.DataRow)
+        {
+            if (set.Tables.Count < 1 || set.Tables[0].Rows.Count < 1)
+            {
+                throw XFlowException.Create("Query don't return valida result");
+            }
+
+            return (TResult)(object)set.Tables[0].Rows[0];
+        }
+
+        if (builder.Mode == DbDirectAccessBuilder.EExecMode.DataTable)
+        {
+            if (set.Tables.Count < 1)
+            {
+                throw XFlowException.Create("Query don't return valida result");
+            }
+
+            return (TResult)(object)set.Tables[0];
+        }
+
+        return (TResult)(object)set;
+    }
+
+    public async Task<TResult> NonQueryAsync<TResult>(Action<DbDirectAccessBuilder> config, CancellationToken cancellationToken)
+    {
+        var context = await provider.GetContextAsync(cancellationToken).ConfigureAwait(false);
+        await using var command = context.CreateCommand();
+
+        var builder = new DbDirectAccessBuilder(this, command);
+        config(builder);
+
+        builder.SetExecutionByReturnType<TResult>();
+        if (builder.Mode == DbDirectAccessBuilder.EExecMode.PrimitiveValue)
+        {
+            return (TResult)(object)command.ExecuteScalarAsync(cancellationToken);
+        }
+
+        var set = new DataSet();
+
+        using var adapter = InternalCreateDataAdapter(command);
+
+        await Task.Run(() => adapter.Fill(set), cancellationToken);
+
+        if (builder.Mode == DbDirectAccessBuilder.EExecMode.DataRow)
+        {
+            if (set.Tables.Count < 1 || set.Tables[0].Rows.Count < 1)
+            {
+                throw XFlowException.Create("Query don't return valida result");
+            }
+
+            return (TResult)(object)set.Tables[0].Rows[0];
+        }
+
+        if (builder.Mode == DbDirectAccessBuilder.EExecMode.DataTable)
+        {
+            if (set.Tables.Count < 1)
+            {
+                throw XFlowException.Create("Query don't return valida result");
+            }
+
+            return (TResult)(object)set.Tables[0];
+        }
+
+        return (TResult)(object)set;
+    }
+
+    public DbParameter CreateParameter(string name, DbType dbType, object? value)
+    {
+        return InternalCreateParameter(name, dbType, value);
+    }
+
     public async Task<DateTime> GetCurrentUtcDateTimeAsync(CancellationToken cancellationToken)
     {
         var dt = await ScalarAsync<DateTime>(InternalGetCurrentUtcDateTimeSql(), CommandType.Text, cancellationToken);
@@ -176,6 +267,7 @@ public abstract class DbDirectAccess(IDbSharedContextProvider provider)
         return DateTime.SpecifyKind(dt, DateTimeKind.Utc);
     }
 
-    protected abstract DbDataAdapter InternalCreateDataAdapter(DbCommand comm);
     protected abstract string InternalGetCurrentUtcDateTimeSql();
+    protected abstract DbDataAdapter InternalCreateDataAdapter(DbCommand comm);
+    protected abstract DbParameter InternalCreateParameter(string name, DbType dbType, object? value);
 }

--- a/src/Keel.Infra.Db/Access/DbDirectAccessBuilder.cs
+++ b/src/Keel.Infra.Db/Access/DbDirectAccessBuilder.cs
@@ -1,0 +1,123 @@
+using System.Data;
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+
+namespace Keel.Infra.Db.Access;
+
+public class DbDirectAccessBuilder(DbDirectAccess access, DbCommand cmd)
+{
+    public enum EExecMode
+    {
+        DataRow,
+        DataTable,
+        DataSet,
+        PrimitiveValue
+    }
+
+    public EExecMode Mode { get; private set; } = EExecMode.DataTable;
+
+    public DbDirectAccessBuilder SetExecutionByReturnType<TResult>()
+    {
+        Mode = IdentifyExecMode<TResult>();
+
+        return this;
+    }
+
+    public DbDirectAccessBuilder SetExecutionMode(EExecMode mode)
+    {
+        Mode = mode;
+
+        return this;
+    }
+
+    public DbDirectAccessBuilder ForCommand(string command, CommandType commandType)
+    {
+        cmd.CommandText = command;
+        cmd.CommandType = commandType;
+
+        return this;
+    }
+
+    public DbDirectAccessBuilder ForText(string command)
+    {
+        cmd.CommandText = command;
+        cmd.CommandType = CommandType.Text;
+
+        return this;
+    }
+
+    public DbDirectAccessBuilder ForStoredProc(string command)
+    {
+        cmd.CommandText = command;
+        cmd.CommandType = CommandType.StoredProcedure;
+
+        return this;
+    }
+
+    public DbDirectAccessBuilder WithTimeout(int timeout)
+    {
+        cmd.CommandTimeout = timeout;
+
+        return this;
+    }
+
+    public DbDirectAccessBuilder AddByte(string name, byte value)
+    {
+        cmd.Parameters.Add(
+            access.CreateParameter(name, DbType.Byte, value));
+
+        return this;
+    }
+
+    public DbDirectAccessBuilder AddInt(string name, int? value)
+    {
+        cmd.Parameters.Add(
+            access.CreateParameter(name, DbType.Int32, value));
+
+        return this;
+    }
+
+    public DbDirectAccessBuilder AddEnum(string name, Enum value)
+    {
+        cmd.Parameters.Add(
+            access.CreateParameter(name, DbType.Int32, value));
+
+        return this;
+    }
+
+    public DbDirectAccessBuilder AddString(string name, string value)
+    {
+        cmd.Parameters.Add(
+            access.CreateParameter(name, DbType.String, value));
+
+        return this;
+    }
+
+    public DbDirectAccessBuilder AddParameters(params SqlParameter[] parameters)
+    {
+        cmd.Parameters.AddRange(parameters);
+
+        return this;
+    }
+
+    private static EExecMode IdentifyExecMode<TResult>()
+    {
+        var type = typeof(TResult);
+        if (type == typeof(DataRow))
+        {
+            return EExecMode.DataRow;
+        }
+
+        if (type == typeof(DataTable))
+        {
+            return EExecMode.DataTable;
+        }
+
+        if (type == typeof(DataSet))
+        {
+            return EExecMode.DataSet;
+        }
+
+        return EExecMode.PrimitiveValue;
+    }
+}

--- a/src/Keel.Infra.Db/Orm/BaseDbContext.cs
+++ b/src/Keel.Infra.Db/Orm/BaseDbContext.cs
@@ -10,7 +10,7 @@ public class BaseDbContext : DbContext, IDbUnitOfWork
     public BaseDbContext() { }
     public BaseDbContext(DbContextOptions options) : base(options) { }
     
-    public async Task<IDbWrappedTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
+    public async Task<IDbWrappedTransaction> BeginTransactionAsync(CancellationToken cancellationToken)
     {
         await _semaphoreSlim.WaitAsync(cancellationToken);
 

--- a/src/Keel.Infra.Db/Orm/Services/DbEntityRepository.cs
+++ b/src/Keel.Infra.Db/Orm/Services/DbEntityRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Linq.Expressions;
 using DotNetAppBase.Std.Exceptions.Assert;
+using DotNetAppBase.Std.Exceptions.Base;
 using DotNetAppBase.Std.Library.ComponentModel.Model.Business;
 using DotNetAppBase.Std.Library.ComponentModel.Model.Business.Enums;
 using DotNetAppBase.Std.Library.ComponentModel.Model.Svc;
@@ -16,6 +17,30 @@ public abstract class DbEntityRepository(IDbLayer dbLayer)
 {
     protected IDbLayer Db => dbLayer;
     protected DbContext Orm => dbLayer.Orm;
+    
+    protected TypedResult<TArg> SecureExecute<TArg>(Func<TypedResult<TArg>> funcTask)
+    {
+        try
+        {
+            return funcTask();
+        }
+        catch (Exception e)
+        {
+            return TypedResult<TArg>.Exception(XException.IsOne(e, out var xEx) ? xEx : e);
+        }
+    }
+
+    protected async Task<TypedResult<TArg>> SecureExecute<TArg>(Func<Task<TypedResult<TArg>>> funcTask)
+    {
+        try
+        {
+            return await funcTask();
+        }
+        catch (Exception e)
+        {
+            return TypedResult<TArg>.Exception(XException.IsOne(e, out var xEx) ? xEx : e);
+        }
+    }
 }
 
 public abstract class DbEntityRepository<TEntity> : DbEntityRepository where TEntity : class, IEntity, new()
@@ -67,8 +92,8 @@ public abstract class DbEntityRepository<TEntity> : DbEntityRepository where TEn
     }
     public virtual Task<ServiceResponse<TEntity>> DeleteAsync(TEntity entity, CancellationToken cancellationToken) => ExecuteDefaultDbAction(entity, EServiceActionType.Delete, cancellationToken);
 
-    protected Task DirectDbAction(
-        EServiceActionType actionType, TEntity entity, CancellationToken cancellationToken) => ExecuteInTransactionContext(entity, actionType, () => GetRepositoryAction(actionType)(entity), cancellationToken);
+    protected Task DirectDbAction(EServiceActionType actionType, TEntity entity, CancellationToken cancellationToken) 
+        => ExecuteInTransactionContext(entity, actionType, () => GetRepositoryAction(actionType)(entity), cancellationToken);
     protected Task DirectDbDelete(TEntity entity, CancellationToken cancellationToken) => DirectDbAction(EServiceActionType.Delete, entity, cancellationToken);
     protected Task DirectDbInsert(TEntity entity, CancellationToken cancellationToken) => DirectDbAction(EServiceActionType.Insert, entity, cancellationToken);
     protected Task DirectDbUpdate(TEntity entity, CancellationToken cancellationToken) => DirectDbAction(EServiceActionType.Update, entity, cancellationToken);

--- a/src/Keel.Infra.Db/Orm/Transaction/DbWrappedTransaction.cs
+++ b/src/Keel.Infra.Db/Orm/Transaction/DbWrappedTransaction.cs
@@ -5,12 +5,12 @@ namespace Keel.Infra.Db.Orm.Transaction;
 internal class DbWrappedTransaction(bool transactionOwner, DatabaseFacade database) 
     : IDbWrappedTransaction
 {
-    public Task CommitAsync(CancellationToken cancellationToken = default)
+    public Task CommitAsync(CancellationToken cancellationToken)
     {
         return transactionOwner ? database.CommitTransactionAsync(cancellationToken) : Task.CompletedTask;
     }
 
-    public Task RollbackAsync(CancellationToken cancellationToken = default)
+    public Task RollbackAsync(CancellationToken cancellationToken)
     {
         return transactionOwner ? database.RollbackTransactionAsync(cancellationToken) : Task.CompletedTask;
     }

--- a/src/Keel.Infra.Db/Orm/Transaction/IDbUnitOfWork.cs
+++ b/src/Keel.Infra.Db/Orm/Transaction/IDbUnitOfWork.cs
@@ -2,5 +2,5 @@ namespace Keel.Infra.Db.Orm.Transaction;
 
 public interface IDbUnitOfWork
 {
-    public Task<IDbWrappedTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default);
+    public Task<IDbWrappedTransaction> BeginTransactionAsync(CancellationToken cancellationToken);
 }

--- a/src/Keel.Infra.Db/Orm/Transaction/IDbWrappedTransaction.cs
+++ b/src/Keel.Infra.Db/Orm/Transaction/IDbWrappedTransaction.cs
@@ -2,6 +2,6 @@ namespace Keel.Infra.Db.Orm.Transaction;
 
 public interface IDbWrappedTransaction
 {
-    Task CommitAsync(CancellationToken cancellationToken = default);
-    Task RollbackAsync(CancellationToken cancellationToken = default);
+    Task CommitAsync(CancellationToken cancellationToken);
+    Task RollbackAsync(CancellationToken cancellationToken);
 }

--- a/src/Keel.Infra.RabbitMQ/IRmqProxy.cs
+++ b/src/Keel.Infra.RabbitMQ/IRmqProxy.cs
@@ -3,7 +3,7 @@
 public interface IRmqProxy
 {
     bool IsConnected { get; }
-    Task<bool> AddAsync(byte[] data, CancellationToken cancellationToken, byte maxAttempts = 3);
+    Task<bool> PublishAsync(byte[] data, CancellationToken cancellationToken, byte maxAttempts = 3);
     Task<bool> ConnectAsync();
     Task DisconnectAsync();
     Task AddSubscriberAsync(RmqSubscriber subscriber);

--- a/src/Keel.Infra.RabbitMQ/Keel.Infra.RabbitMQ.csproj
+++ b/src/Keel.Infra.RabbitMQ/Keel.Infra.RabbitMQ.csproj
@@ -10,7 +10,8 @@
     <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.2" />
-    <PackageReference Include="RabbitMQ.Client" Version="7.1.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.1.2" />
   </ItemGroup>
 </Project>

--- a/src/Keel.Infra.RabbitMQ/Producer/Producer.cs
+++ b/src/Keel.Infra.RabbitMQ/Producer/Producer.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using RabbitMQ.Client;
+
+namespace Keel.Infra.RabbitMQ.Producer;
+
+public class Producer<TEnvelope>(IConnection connection) : IProducer<TEnvelope>
+    where TEnvelope : IEnvelope
+{
+    public async Task PublishAsync(TEnvelope envelope, CancellationToken cancellationToken)
+    {
+        if (envelope == null)
+        {
+            throw new ArgumentNullException(nameof(envelope));
+        }
+
+        var payload = new MemoryStream();
+        await JsonSerializer.SerializeAsync(payload, envelope.Payload, cancellationToken: cancellationToken);
+        payload.Position = 0;
+
+        await using var channel = await connection.CreateChannelAsync(cancellationToken: cancellationToken);
+        
+        await channel!.BasicPublishAsync(
+                exchange: envelope.Exchange,
+                routingKey: envelope.QueueName,
+                mandatory: true,
+                basicProperties: new BasicProperties
+                {
+                    Persistent = true,
+                },
+                body: payload.ToArray(),
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+}
+
+public interface IProducer<in TEnvelope>
+    where TEnvelope : IEnvelope
+{
+    Task PublishAsync(TEnvelope envelope, CancellationToken cancellationToken);
+}
+
+public interface IEnvelope
+{
+    string Exchange { get; }
+    string QueueName { get; }
+    object Payload { get; }
+}

--- a/src/Keel.Infra.RabbitMQ/RmqProxy.cs
+++ b/src/Keel.Infra.RabbitMQ/RmqProxy.cs
@@ -1,10 +1,12 @@
-﻿using RabbitMQ.Client;
+﻿using Microsoft.Extensions.Logging;
+using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 
 namespace Keel.Infra.RabbitMQ;
 
 public class RmqProxy : IRmqProxy
 {
+    private readonly ILogger<RmqProxy> _logger;
     private readonly RmqQueueEndpoint _endpoint;
     private readonly Lazy<ConnectionFactory> _lazyConnFactory;
 
@@ -16,9 +18,11 @@ public class RmqProxy : IRmqProxy
     private IConnection? _connection;
     private BasicProperties? _defProperties;
 
-    public RmqProxy(RmqQueueEndpoint endpointOptions)
+    public RmqProxy(ILogger<RmqProxy> logger, RmqQueueEndpoint endpointOptions)
     {
+        _logger = logger;
         _endpoint = endpointOptions;
+        
         _subscribers = [];
 
         _lazyConnFactory = new Lazy<ConnectionFactory>(
@@ -35,7 +39,7 @@ public class RmqProxy : IRmqProxy
 
     public bool IsConnected => _channel != null;
 
-    public async Task<bool> AddAsync(byte[] data, CancellationToken cancellationToken, byte maxAttempts = 3)
+    public async Task<bool> PublishAsync(byte[] data, CancellationToken cancellationToken, byte maxAttempts = 3)
     {
         var i = 0;
 

--- a/src/Keel.Infra.WebApi/Db/DbApiController.cs
+++ b/src/Keel.Infra.WebApi/Db/DbApiController.cs
@@ -54,20 +54,11 @@ public abstract class DbApiController<TModel, TService>(IDbLayer dbLayer, TServi
 
     protected Task<TypedResult<IEnumerable<TModel>>> InternalGetAllAsync(CancellationToken cancellationToken) => InternalExecuteGetAsync(Svc.GetAllAsync(cancellationToken));
 
-    protected virtual async Task<LoadResult> InternalGetAsync(DataSourceLoadOptions loadOptions)
+    protected virtual async Task<LoadResult> InternalGetAsync(DataSourceLoadOptions loadOptions, CancellationToken cancellationToken)
     {
-        try
-        {
-            var data = await Svc.GetQuery().ToArrayAsync();
-            var result = await InternalExecuteGetAsync(Task.Run(() => data.AsQueryable()), loadOptions);
-
-            return result;
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e);
-            throw;
-        }
+        var data = await Svc.GetQuery().ToArrayAsync(cancellationToken);
+        var result = await InternalExecuteGetAsync(data.AsQueryable(), loadOptions, cancellationToken);
+        return result;
     }
 
     protected async Task<TypedResult<TModel>> InternalGetByIdAsync(int key, CancellationToken cancellationToken)
@@ -81,10 +72,10 @@ public abstract class DbApiController<TModel, TService>(IDbLayer dbLayer, TServi
                 });
     }
 
-    protected async Task<LoadResult> InternalGetToComposeAsync(DataSourceLoadOptions loadOptions)
+    protected Task<LoadResult> InternalGetToComposeAsync(DataSourceLoadOptions loadOptions, CancellationToken cancellationToken)
     {
         var query = Svc.GetToComposeQuery();
-        var result = await DataSourceLoader.LoadAsync(query, loadOptions);
+        var result = DataSourceLoader.LoadAsync(query, loadOptions, cancellationToken);
         return result;
     }
 
@@ -184,5 +175,9 @@ public abstract class DbApiController<TModel, TService>(IDbLayer dbLayer, TServi
 
     protected LoadResult InternalExecuteGet(IQueryable<dynamic> query, DataSourceLoadOptions loadOptions) => DataSourceLoader.Load(query, loadOptions);
 
-    protected async Task<LoadResult> InternalExecuteGetAsync(Task<IQueryable<TModel>> asyncQuer, DataSourceLoadOptions loadOptions) => DataSourceLoader.Load(await asyncQuer, loadOptions);
+    protected Task<LoadResult> InternalExecuteGetAsync(IQueryable<TModel> asyncQuer, DataSourceLoadOptions loadOptions, CancellationToken cancellationToken)
+    {
+        var result = DataSourceLoader.Load(asyncQuer, loadOptions);
+        return Task.FromResult(result);
+    }
 }


### PR DESCRIPTION
## Description

This pull request includes the following updates:

- Refactored parameter handling in `DbDapperAccess` methods.
- Introduced `DbDirectAccessBuilder` for command configuration.
- Removed default cancellation token parameter from transaction methods for consistent method signatures.
- Enhanced `InternalGetAsync` and `InternalGetToComposeAsync` methods to support cancellation tokens.
- Added `Producer` class for RabbitMQ message publishing functionality.
- Updated `RmqProxy` to use `PublishAsync` for message handling improvements.