### PR TITLE
Add GitHub Packages workflows for each Keel project

### DIFF
--- a/.github/workflows/publish-keel-domain-cleancode.yml
+++ b/.github/workflows/publish-keel-domain-cleancode.yml
@@ -6,6 +6,10 @@ on:
     tags:
       - "Keel.Domain.CleanCode-v*"
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish:
     uses: ./.github/workflows/publish-dotnet-package.yml

--- a/.github/workflows/publish-keel-infra-broker-rabbitmq.yml
+++ b/.github/workflows/publish-keel-infra-broker-rabbitmq.yml
@@ -6,6 +6,10 @@ on:
     tags:
       - "Keel.Infra.Broker.RabbitMQ-v*"
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish:
     uses: ./.github/workflows/publish-dotnet-package.yml

--- a/.github/workflows/publish-keel-infra-db-sqlserver.yml
+++ b/.github/workflows/publish-keel-infra-db-sqlserver.yml
@@ -6,6 +6,10 @@ on:
     tags:
       - "Keel.Infra.Db.SqlServer-v*"
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish:
     uses: ./.github/workflows/publish-dotnet-package.yml

--- a/.github/workflows/publish-keel-infra-db.yml
+++ b/.github/workflows/publish-keel-infra-db.yml
@@ -6,6 +6,10 @@ on:
     tags:
       - "Keel.Infra.Db-v*"
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish:
     uses: ./.github/workflows/publish-dotnet-package.yml

--- a/.github/workflows/publish-keel-infra-rabbitmq.yml
+++ b/.github/workflows/publish-keel-infra-rabbitmq.yml
@@ -6,6 +6,10 @@ on:
     tags:
       - "Keel.Infra.RabbitMQ-v*"
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish:
     uses: ./.github/workflows/publish-dotnet-package.yml

--- a/.github/workflows/publish-keel-infra-webapi.yml
+++ b/.github/workflows/publish-keel-infra-webapi.yml
@@ -6,6 +6,10 @@ on:
     tags:
       - "Keel.Infra.WebApi-v*"
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish:
     uses: ./.github/workflows/publish-dotnet-package.yml

--- a/.idea/.idea.Keel/.idea/indexLayout.xml
+++ b/.idea/.idea.Keel/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.Keel/.idea/projectSettingsUpdater.xml
+++ b/.idea/.idea.Keel/.idea/projectSettingsUpdater.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RiderProjectSettingsUpdater">
+    <option name="singleClickDiffPreview" value="1" />
+    <option name="unhandledExceptionsIgnoreList" value="1" />
+    <option name="vcsConfiguration" value="3" />
+  </component>
+</project>

--- a/.idea/.idea.Keel/.idea/vcs.xml
+++ b/.idea/.idea.Keel/.idea/vcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.idea/.idea.Keel/.idea/workspace.xml
+++ b/.idea/.idea.Keel/.idea/workspace.xml
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="CMakeProjectFlavorService">
+    <option name="flavorId" value="CMakePlainProjectFlavor" />
+  </component>
+  <component name="CMakeSettings">
+    <configurations />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="5c4fa8d0-229f-4538-ad73-b4c0e5732f1c" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ChangesViewManager">
+    <option name="groupingKeys">
+      <option value="directory" />
+      <option value="repository" />
+    </option>
+  </component>
+  <component name="CopilotPersistence">
+    <persistenceIdMap>
+      <entry key="_/Users/adrianosepe/x-src/oss/Keel" value="2wL70YBQ6uivn98wFpGoJ3VqtVA" />
+    </persistenceIdMap>
+  </component>
+  <component name="EmbeddingIndexingInfo">
+    <option name="cachedIndexableFilesCount" value="29" />
+    <option name="fileBasedEmbeddingIndicesEnabled" value="true" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_BRANCH_BY_REPOSITORY">
+      <map>
+        <entry key="$PROJECT_DIR$" value="feature/fase-4" />
+      </map>
+    </option>
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="GitHubPullRequestSearchHistory">{
+  &quot;lastFilter&quot;: {}
+}</component>
+  <component name="GitHubPullRequestState">{
+  &quot;prStates&quot;: [
+    {
+      &quot;id&quot;: {
+        &quot;id&quot;: &quot;PR_kwDOOBoMH87SWXEe&quot;,
+        &quot;number&quot;: 23
+      },
+      &quot;lastSeen&quot;: 1776179255308
+    }
+  ]
+}</component>
+  <component name="GithubPullRequestsUISettings">{
+  &quot;selectedUrlAndAccountId&quot;: {
+    &quot;url&quot;: &quot;https://github.com/adrianosepe/Keel.git&quot;,
+    &quot;accountId&quot;: &quot;4b30d13c-520c-451f-9938-79fec1a3b5c9&quot;
+  },
+  &quot;recentNewPullRequestHead&quot;: {
+    &quot;server&quot;: {
+      &quot;useHttp&quot;: false,
+      &quot;host&quot;: &quot;github.com&quot;,
+      &quot;port&quot;: null,
+      &quot;suffix&quot;: null
+    },
+    &quot;owner&quot;: &quot;adrianosepe&quot;,
+    &quot;repository&quot;: &quot;Keel&quot;
+  }
+}</component>
+  <component name="HighlightingSettingsPerFile">
+    <setting file="file://$PROJECT_DIR$/src/Keel.Infra.Db.SqlServer/Access/DbDapperAccessExtensions.cs" root0="FORCE_HIGHLIGHTING" />
+    <setting file="jar://$APPLICATION_HOME_DIR$/lib/modules/intellij.rider.jar!/schemas/msbuild/Microsoft.Build.Commontypes.xsd" root0="FORCE_HIGHLIGHTING" />
+  </component>
+  <component name="McpProjectServerCommands">
+    <commands />
+    <urls />
+  </component>
+  <component name="MetaFilesCheckinStateConfiguration" checkMetaFiles="true" />
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 7
+}</component>
+  <component name="ProjectId" id="2wL70YBQ6uivn98wFpGoJ3VqtVA" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.MCP Project settings loaded&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.cidr.known.project.marker&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.readMode.enableVisualFormatting&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.typescript.service.memoryLimit.init&quot;: &quot;true&quot;,
+    &quot;cidr.known.project.marker&quot;: &quot;true&quot;,
+    &quot;codeWithMe.voiceChat.enabledByDefault&quot;: &quot;false&quot;,
+    &quot;com.intellij.ml.llm.matterhorn.ej.ui.settings.DefaultModelSelectionForGA.v1&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;#26 on feat/iotag-support&quot;,
+    &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.keymap&quot;,
+    &quot;to.speed.mode.migration.done&quot;: &quot;true&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  }
+}</component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="5c4fa8d0-229f-4538-ad73-b4c0e5732f1c" name="Changes" comment="" />
+      <created>1745808778269</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1745808778269</updated>
+      <workItem from="1745808780289" duration="313000" />
+      <workItem from="1748123832720" duration="4856000" />
+      <workItem from="1758392927337" duration="10885000" />
+      <workItem from="1776178041816" duration="1241000" />
+      <workItem from="1776179426165" duration="1705000" />
+      <workItem from="1776816444639" duration="1207000" />
+      <workItem from="1776822460506" duration="48000" />
+      <workItem from="1776823176246" duration="3045000" />
+    </task>
+    <task id="LOCAL-00001" summary="Improvements to support integration on real projects">
+      <option name="closed" value="true" />
+      <created>1745808926664</created>
+      <option name="number" value="00001" />
+      <option name="presentableId" value="LOCAL-00001" />
+      <option name="project" value="LOCAL" />
+      <updated>1745808926664</updated>
+    </task>
+    <task id="LOCAL-00002" summary="refactor: Rename DbDirectAccessBuilder to SqlDirectAccessBuilder and update constructor parameters">
+      <option name="closed" value="true" />
+      <created>1776178718965</created>
+      <option name="number" value="00002" />
+      <option name="presentableId" value="LOCAL-00002" />
+      <option name="project" value="LOCAL" />
+      <updated>1776178718965</updated>
+    </task>
+    <task id="LOCAL-00003" summary="chore: Update .gitignore to exclude .DS_Store files">
+      <option name="closed" value="true" />
+      <created>1776181128585</created>
+      <option name="number" value="00003" />
+      <option name="presentableId" value="LOCAL-00003" />
+      <option name="project" value="LOCAL" />
+      <updated>1776181128585</updated>
+    </task>
+    <task id="LOCAL-00004" summary="refactor: Rename SqlDapperAccessExtensions and SqlDirectAccessBuilder to DbDapperAccessExtensions and DbDirectAccessBuilder for consistency">
+      <option name="closed" value="true" />
+      <created>1776181329393</created>
+      <option name="number" value="00004" />
+      <option name="presentableId" value="LOCAL-00004" />
+      <option name="project" value="LOCAL" />
+      <updated>1776181329393</updated>
+    </task>
+    <task id="LOCAL-00005" summary="feat: Update project files for improved package management and documentation">
+      <option name="closed" value="true" />
+      <created>1776823798731</created>
+      <option name="number" value="00005" />
+      <option name="presentableId" value="LOCAL-00005" />
+      <option name="project" value="LOCAL" />
+      <updated>1776823798731</updated>
+    </task>
+    <task id="LOCAL-00006" summary="feat: Add GitHub Actions workflows for publishing .NET packages">
+      <option name="closed" value="true" />
+      <created>1776823810002</created>
+      <option name="number" value="00006" />
+      <option name="presentableId" value="LOCAL-00006" />
+      <option name="project" value="LOCAL" />
+      <updated>1776823810002</updated>
+    </task>
+    <task id="LOCAL-00007" summary="feat: Add Directory.Build.props for .NET package configuration">
+      <option name="closed" value="true" />
+      <created>1776823821840</created>
+      <option name="number" value="00007" />
+      <option name="presentableId" value="LOCAL-00007" />
+      <option name="project" value="LOCAL" />
+      <updated>1776823821840</updated>
+    </task>
+    <option name="localTasksCounter" value="8" />
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="UnityCheckinConfiguration" checkUnsavedScenes="true" />
+  <component name="UnityProjectConfiguration" hasMinimizedUI="false" />
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="MAIN">
+          <value>
+            <State>
+              <option name="FILTERS">
+                <map>
+                  <entry key="branch">
+                    <value>
+                      <list>
+                        <option value="develop" />
+                      </list>
+                    </value>
+                  </entry>
+                </map>
+              </option>
+            </State>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+  <component name="VcsManagerConfiguration">
+    <option name="CLEAR_INITIAL_COMMIT_MESSAGE" value="true" />
+    <MESSAGE value="Improvements to support integration on real projects" />
+    <MESSAGE value="refactor: Rename DbDirectAccessBuilder to SqlDirectAccessBuilder and update constructor parameters" />
+    <MESSAGE value="chore: Update .gitignore to exclude .DS_Store files" />
+    <MESSAGE value="refactor: Rename SqlDapperAccessExtensions and SqlDirectAccessBuilder to DbDapperAccessExtensions and DbDirectAccessBuilder for consistency" />
+    <MESSAGE value="feat: Update project files for improved package management and documentation" />
+    <MESSAGE value="feat: Add GitHub Actions workflows for publishing .NET packages" />
+    <MESSAGE value="feat: Add Directory.Build.props for .NET package configuration" />
+    <option name="LAST_COMMIT_MESSAGE" value="feat: Add Directory.Build.props for .NET package configuration" />
+  </component>
+  <component name="XDebuggerManager">
+    <breakpoint-manager>
+      <breakpoints>
+        <breakpoint enabled="true" type="DotNet_Exception_Breakpoints">
+          <properties exception="System.OperationCanceledException" breakIfHandledByOtherCode="false" displayValue="System.OperationCanceledException" />
+          <option name="timeStamp" value="1" />
+        </breakpoint>
+        <breakpoint enabled="true" type="DotNet_Exception_Breakpoints">
+          <properties exception="System.Threading.Tasks.TaskCanceledException" breakIfHandledByOtherCode="false" displayValue="System.Threading.Tasks.TaskCanceledException" />
+          <option name="timeStamp" value="2" />
+        </breakpoint>
+        <breakpoint enabled="true" type="DotNet_Exception_Breakpoints">
+          <properties exception="System.Threading.ThreadAbortException" breakIfHandledByOtherCode="false" displayValue="System.Threading.ThreadAbortException" />
+          <option name="timeStamp" value="3" />
+        </breakpoint>
+      </breakpoints>
+    </breakpoint-manager>
+  </component>
+  <component name="github-copilot-workspace">
+    <instructionFileLocations>
+      <option value=".github/instructions" />
+    </instructionFileLocations>
+    <promptFileLocations>
+      <option value=".github/prompts" />
+    </promptFileLocations>
+  </component>
+</project>


### PR DESCRIPTION
## Summary
- Add a reusable GitHub Actions workflow to pack and publish .NET packages to GitHub Packages.
- Add one publish workflow per Keel project, with explicit package write permissions for reusable workflow calls.
- Centralize common NuGet metadata in `Directory.Build.props` and include the repository README in packages.
- Replace the local ASP.NET DLL reference in `Keel.Domain.CleanCode` with a framework reference so CI packaging works reliably.
- Update `Keel.Infra.WebApi` packaging metadata and remove the old NuGet.org publish workflow.

## Testing
- `dotnet build Keel.sln` passed locally.
- `dotnet pack` succeeded locally for the library projects that were validated, including `Keel.Domain.CleanCode`, `Keel.Infra.Db`, `Keel.Infra.Db.SqlServer`, `Keel.Infra.RabbitMQ`, and `Keel.Infra.Broker.RabbitMQ`.
- `Keel.Infra.WebApi` compiles in Release; packaging was adjusted for CI compatibility, but full GitHub Actions validation is still pending.