### PR TITLE
Add GitHub Actions and NuGet publishing for Keel packages

### DIFF
--- a/.github/workflows/publish-keel-domain-cleancode.yml
+++ b/.github/workflows/publish-keel-domain-cleancode.yml
@@ -11,8 +11,15 @@ permissions:
   packages: write
 
 jobs:
-  publish:
+  publish_github_packages:
     uses: ./.github/workflows/publish-dotnet-package.yml
     with:
       project_path: src/Keel.Domain.CleanCode/Keel.Domain.CleanCode.csproj
     secrets: inherit
+
+  publish_nugetorg:
+    uses: ./.github/workflows/publish-nugetorg-package.yml
+    with:
+      project_path: src/Keel.Domain.CleanCode/Keel.Domain.CleanCode.csproj
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-keel-infra-broker-rabbitmq.yml
+++ b/.github/workflows/publish-keel-infra-broker-rabbitmq.yml
@@ -11,8 +11,15 @@ permissions:
   packages: write
 
 jobs:
-  publish:
+  publish_github_packages:
     uses: ./.github/workflows/publish-dotnet-package.yml
     with:
       project_path: src/Keel.Infra.Broker.RabbitMQ/Keel.Infra.Broker.RabbitMQ.csproj
     secrets: inherit
+
+  publish_nugetorg:
+    uses: ./.github/workflows/publish-nugetorg-package.yml
+    with:
+      project_path: src/Keel.Infra.Broker.RabbitMQ/Keel.Infra.Broker.RabbitMQ.csproj
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-keel-infra-db-sqlserver.yml
+++ b/.github/workflows/publish-keel-infra-db-sqlserver.yml
@@ -11,8 +11,15 @@ permissions:
   packages: write
 
 jobs:
-  publish:
+  publish_github_packages:
     uses: ./.github/workflows/publish-dotnet-package.yml
     with:
       project_path: src/Keel.Infra.Db.SqlServer/Keel.Infra.Db.SqlServer.csproj
     secrets: inherit
+
+  publish_nugetorg:
+    uses: ./.github/workflows/publish-nugetorg-package.yml
+    with:
+      project_path: src/Keel.Infra.Db.SqlServer/Keel.Infra.Db.SqlServer.csproj
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-keel-infra-db.yml
+++ b/.github/workflows/publish-keel-infra-db.yml
@@ -11,8 +11,15 @@ permissions:
   packages: write
 
 jobs:
-  publish:
+  publish_github_packages:
     uses: ./.github/workflows/publish-dotnet-package.yml
     with:
       project_path: src/Keel.Infra.Db/Keel.Infra.Db.csproj
     secrets: inherit
+
+  publish_nugetorg:
+    uses: ./.github/workflows/publish-nugetorg-package.yml
+    with:
+      project_path: src/Keel.Infra.Db/Keel.Infra.Db.csproj
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-keel-infra-rabbitmq.yml
+++ b/.github/workflows/publish-keel-infra-rabbitmq.yml
@@ -11,8 +11,15 @@ permissions:
   packages: write
 
 jobs:
-  publish:
+  publish_github_packages:
     uses: ./.github/workflows/publish-dotnet-package.yml
     with:
       project_path: src/Keel.Infra.RabbitMQ/Keel.Infra.RabbitMQ.csproj
     secrets: inherit
+
+  publish_nugetorg:
+    uses: ./.github/workflows/publish-nugetorg-package.yml
+    with:
+      project_path: src/Keel.Infra.RabbitMQ/Keel.Infra.RabbitMQ.csproj
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-keel-infra-webapi.yml
+++ b/.github/workflows/publish-keel-infra-webapi.yml
@@ -11,8 +11,15 @@ permissions:
   packages: write
 
 jobs:
-  publish:
+  publish_github_packages:
     uses: ./.github/workflows/publish-dotnet-package.yml
     with:
       project_path: src/Keel.Infra.WebApi/Keel.Infra.WebApi.csproj
     secrets: inherit
+
+  publish_nugetorg:
+    uses: ./.github/workflows/publish-nugetorg-package.yml
+    with:
+      project_path: src/Keel.Infra.WebApi/Keel.Infra.WebApi.csproj
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish-nugetorg-package.yml
+++ b/.github/workflows/publish-nugetorg-package.yml
@@ -1,0 +1,45 @@
+name: Publish .NET Package to NuGet.org
+
+on:
+  workflow_call:
+    inputs:
+      project_path:
+        description: Path to the .csproj to pack and publish
+        required: true
+        type: string
+    secrets:
+      NUGET_API_KEY:
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Restore project
+        run: dotnet restore "${{ inputs.project_path }}"
+
+      - name: Build project
+        run: dotnet build "${{ inputs.project_path }}" --configuration Release --no-restore /p:ContinuousIntegrationBuild=true
+
+      - name: Pack project
+        run: dotnet pack "${{ inputs.project_path }}" --configuration Release --no-build --output "${{ github.workspace }}/artifacts"
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.workflow }}-${{ github.run_number }}-nugetorg
+          path: ${{ github.workspace }}/artifacts
+
+      - name: Publish package to NuGet.org
+        run: dotnet nuget push "${{ github.workspace }}/artifacts/*.nupkg" --source "https://api.nuget.org/v3/index.json" --api-key "${{ secrets.NUGET_API_KEY }}" --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Project base to support microservices using .NET
 
 Each project has its own GitHub Actions workflow for creating and publishing a NuGet package to GitHub Packages.
 
+The same workflow run also publishes the package to NuGet.org.
+
 - Manual publish: run the workflow for the project in the `Actions` tab.
 - Publish by tag: create a tag using the format `<PackageId>-v<version>`.
 
@@ -17,3 +19,8 @@ Examples:
 Packages are published to:
 
 - `https://nuget.pkg.github.com/adrianosepe/index.json`
+- `https://www.nuget.org/packages`
+
+Required GitHub Actions secret:
+
+- `NUGET_API_KEY`: API key generated in NuGet.org for package push


### PR DESCRIPTION
## Summary
- Added reusable GitHub Actions workflows to pack and publish each Keel project.
- Enabled publishing to both GitHub Packages and NuGet.org from the same project workflows.
- Centralized NuGet metadata in `Directory.Build.props` and updated packageable project settings for CI-friendly builds.
- Replaced local ASP.NET DLL references in `Keel.Domain.CleanCode` with a framework reference so packaging works in CI.
- Removed the legacy NuGet-only workflow and updated the README with publishing and consumption details.

## Testing
- `dotnet build Keel.sln` passed locally.
- `dotnet pack` was validated locally for the package projects updated in this change.
- Workflow YAMLs were reviewed for reusable workflow call and permissions compatibility.