### PR TITLE
Fix publishing workflows and package targets

### DIFF
--- a/.github/workflows/publish-dotnet-package.yml
+++ b/.github/workflows/publish-dotnet-package.yml
@@ -24,6 +24,22 @@ jobs:
         with:
           dotnet-version: 9.0.x
 
+      - name: Validate package version tag
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          package_id="$(dotnet msbuild "${{ inputs.project_path }}" -getProperty:PackageId)"
+          package_version="$(dotnet msbuild "${{ inputs.project_path }}" -getProperty:Version)"
+          expected_tag="${package_id}-v${package_version}"
+
+          if [[ "${GITHUB_REF_NAME}" != "${expected_tag}" ]]; then
+            echo "Tag '${GITHUB_REF_NAME}' does not match package version."
+            echo "Expected tag: ${expected_tag}"
+            exit 1
+          fi
+
       - name: Restore project
         run: dotnet restore "${{ inputs.project_path }}"
 

--- a/.github/workflows/publish-nugetorg-package.yml
+++ b/.github/workflows/publish-nugetorg-package.yml
@@ -26,6 +26,22 @@ jobs:
         with:
           dotnet-version: 9.0.x
 
+      - name: Validate package version tag
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          package_id="$(dotnet msbuild "${{ inputs.project_path }}" -getProperty:PackageId)"
+          package_version="$(dotnet msbuild "${{ inputs.project_path }}" -getProperty:Version)"
+          expected_tag="${package_id}-v${package_version}"
+
+          if [[ "${GITHUB_REF_NAME}" != "${expected_tag}" ]]; then
+            echo "Tag '${GITHUB_REF_NAME}' does not match package version."
+            echo "Expected tag: ${expected_tag}"
+            exit 1
+          fi
+
       - name: Restore project
         run: dotnet restore "${{ inputs.project_path }}"
 

--- a/.idea/.idea.Keel/.idea/workspace.xml
+++ b/.idea/.idea.Keel/.idea/workspace.xml
@@ -10,7 +10,9 @@
     <configurations />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="5c4fa8d0-229f-4538-ad73-b4c0e5732f1c" name="Changes" comment="" />
+    <list default="true" id="5c4fa8d0-229f-4538-ad73-b4c0e5732f1c" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/.idea.Keel/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Keel/.idea/workspace.xml" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -24,11 +26,12 @@
   </component>
   <component name="CopilotPersistence">
     <persistenceIdMap>
+      <entry key="_/Users/adrianosepe/x-src/evul/Keel" value="3Cr1oEC6XJdRtWd1KzAGbPMMc0G" />
       <entry key="_/Users/adrianosepe/x-src/oss/Keel" value="2wL70YBQ6uivn98wFpGoJ3VqtVA" />
     </persistenceIdMap>
   </component>
   <component name="EmbeddingIndexingInfo">
-    <option name="cachedIndexableFilesCount" value="29" />
+    <option name="cachedIndexableFilesCount" value="6" />
     <option name="fileBasedEmbeddingIndicesEnabled" value="true" />
   </component>
   <component name="Git.Settings">
@@ -86,31 +89,32 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.MCP Project settings loaded&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.cidr.known.project.marker&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.readMode.enableVisualFormatting&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.typescript.service.memoryLimit.init&quot;: &quot;true&quot;,
-    &quot;cidr.known.project.marker&quot;: &quot;true&quot;,
-    &quot;codeWithMe.voiceChat.enabledByDefault&quot;: &quot;false&quot;,
-    &quot;com.intellij.ml.llm.matterhorn.ej.ui.settings.DefaultModelSelectionForGA.v1&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;#26 on feat/iotag-support&quot;,
-    &quot;junie.onboarding.icon.badge.shown&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.keymap&quot;,
-    &quot;to.speed.mode.migration.done&quot;: &quot;true&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.MCP Project settings loaded": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.cidr.known.project.marker": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.readMode.enableVisualFormatting": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "cidr.known.project.marker": "true",
+    "codeWithMe.voiceChat.enabledByDefault": "false",
+    "com.intellij.ml.llm.matterhorn.ej.ui.settings.DefaultModelSelectionForGA.v1": "true",
+    "git-widget-placeholder": "feat/iotag-support",
+    "junie.onboarding.icon.badge.shown": "true",
+    "last_opened_file_path": "/Users/adrianosepe/x-src/evul/Keel/Keel.sln",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "preferences.keymap",
+    "to.speed.mode.migration.done": "true",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="TaskManager">
     <task active="true" id="Default" summary="Default task">
       <changelist id="5c4fa8d0-229f-4538-ad73-b4c0e5732f1c" name="Changes" comment="" />
@@ -126,6 +130,8 @@
       <workItem from="1776816444639" duration="1207000" />
       <workItem from="1776822460506" duration="48000" />
       <workItem from="1776823176246" duration="3045000" />
+      <workItem from="1776910863417" duration="1269000" />
+      <workItem from="1777129049097" duration="108000" />
     </task>
     <task id="LOCAL-00001" summary="Improvements to support integration on real projects">
       <option name="closed" value="true" />

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Each project has its own GitHub Actions workflow for creating and publishing a N
 The same workflow run also publishes the package to NuGet.org.
 
 - Manual publish: run the workflow for the project in the `Actions` tab.
-- Publish by tag: create a tag using the format `<PackageId>-v<version>`.
+- Publish by tag: create a tag using the format `<PackageId>-v<version>`. The `<version>` value must match the package `Version` evaluated by MSBuild.
 
 Examples:
 


### PR DESCRIPTION
## Summary
- Update GitHub Actions workflows for publishing .NET and NuGet packages
- Align project and build configuration for the Keel domain, infra, and web API projects
- Refresh repository docs and ignore rules to match the new publish setup

## Testing
- Not run (not requested)